### PR TITLE
chore: Bump trivy to 0.35.0

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -43,33 +43,33 @@ jobs:
               docker-daemon:trivy/charmed-opensearch-dashboards:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: 'trivy/charmed-opensearch-dashboards:test'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'MEDIUM,HIGH,CRITICAL'
+          image-ref: "trivy/charmed-opensearch-dashboards:test"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
-          scan-type: 'image'
-          format: 'spdx-json'
-          output: 'dependency-results.sbom.json'
-          image-ref: 'trivy/charmed-opensearch-dashboards:test'
+          scan-type: "image"
+          format: "spdx-json"
+          output: "dependency-results.sbom.json"
+          image-ref: "trivy/charmed-opensearch-dashboards:test"
           github-pat: ${{ secrets.GITHUB_TOKEN }}
-          severity: 'MEDIUM,HIGH,CRITICAL'
-          scanners: 'vuln'
+          severity: "MEDIUM,HIGH,CRITICAL"
+          scanners: "vuln"
 
       - name: Upload trivy report as a Github artifact
         uses: actions/upload-artifact@v4
         with:
           name: trivy-sbom-report
-          path: '${{ github.workspace }}/dependency-results.sbom.json'
+          path: "${{ github.workspace }}/dependency-results.sbom.json"
           retention-days: 90


### PR DESCRIPTION
https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release