### PR TITLE
Remove default properties and add run user for services

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,12 +94,19 @@ jobs:
             charmed-opensearch:"${version}"
          )
          opensearch_cont_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${opensearch_cont}")
-
+         
+         cat <<EOF > opensearch_dashboards.yml
+         server.host: "0.0.0.0"
+         opensearch_security.enabled: false
+         path.data: "/var/lib/opensearch-dashboards"
+         opensearch.hosts: ["http://${opensearch_cont_ip}:9200"]
+         EOF
+         
          docker run -d --rm \
              --name dashboards \
              -p 127.0.0.1:5601:5601 \
              -p 127.0.0.1:9684:9684 \
-             -e OPENSEARCH_HOSTS='["http://'"${opensearch_cont_ip}"':9200"]' \
+             -v $(pwd)/opensearch_dashboards.yml:/etc/opensearch-dashboards/opensearch_dashboards.yml \
              charmed-opensearch-dashboards:"${version}"
          
          sleep 10s

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,7 +4,7 @@ name: charmed-opensearch-dashboards
 base: ubuntu@24.04 # the base environment for this rock
 license: Apache-2.0
 
-version: '2.19.2' # just for humans. Semantic versioning is recommended
+version: '2.19.4' # just for humans. Semantic versioning is recommended
 
 summary: 'OpenSearch Dashboards: community-driven OpenSearch visualization suite.'
 description: |
@@ -23,6 +23,8 @@ services:
     startup: enabled
     summary: Start Opensearch Dashboards
     command: '/bin/bash /bin/start.sh'
+    "user": "_daemon_"
+    "group": "_daemon_"
     environment:
       OPS_ROOT: /opt/opensearch-dashboards
       OPENSEARCH_DASHBOARDS_HOME: /usr/share/opensearch-dashboards
@@ -38,6 +40,8 @@ services:
     startup: enabled
     summary: Start Prometheus Exporter
     command: '/bin/bash /bin/start-exporter.sh'
+    user: "_daemon_"
+    group: "_daemon_"
     environment: 
       OPENSEARCH_DASHBOARDS_PATH_CONF: /etc/opensearch-dashboards
       PYTHONPATH: "/usr/lib/python3/dist-packages:$PYTHONPATH"

--- a/scripts/start-exporter.sh
+++ b/scripts/start-exporter.sh
@@ -5,7 +5,7 @@ set -eu
 source "/usr/bin/get-conf.sh"
 
 function fetch_exporter_args () {
-    DASHBOARDS_HOST="localhost"
+    DASHBOARDS_HOST=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.host" "0.0.0.0" )
     DASHBOARDS_PORT=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.port" "5601" )
     DASHBOARDS_USER=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.username" "" )
     DASHBOARDS_PASSWORD=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.password" "" )

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,46 +3,6 @@
 set -e
 source "/usr/bin/set-conf.sh"
 
-opensearch_dashboards_vars=(
-    opensearch.hosts
-    opensearch.ssl.certificate
-    opensearch.ssl.certificateAuthorities
-    opensearch.ssl.key
-    opensearch.ssl.keyPassphrase
-    opensearch.ssl.keystore.path
-    opensearch.ssl.keystore.password
-    opensearch.ssl.truststore.path
-    opensearch.ssl.truststore.password
-    opensearch.ssl.verificationMode
-    opensearch_security.enabled
-    server.host
-    server.port
-    server.ssl.certificate
-    server.ssl.enabled
-    server.ssl.key
-
-)
-
-OPENSEARCH_DASHBOARDS_CONF="${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml"
-
-function set_base_config_props () {
-    set_yaml_prop "${OPENSEARCH_DASHBOARDS_CONF}" "server.host" "0.0.0.0"
-    set_yaml_prop "${OPENSEARCH_DASHBOARDS_CONF}" "opensearch_security.enabled" "false"
-    set_yaml_prop "${OPENSEARCH_DASHBOARDS_CONF}" "path.data" "${OPENSEARCH_DASHBOARDS_VARLIB}"
-}
-
-function read_env_vars () {
-    # transforms config variables to possible env vars. eg opensearch.hosts -> OPENSEARCH_HOSTS
-    # see https://github.com/opensearch-project/OpenSearch-Dashboards/blob/72fa1239edc09780bdb854bef3c9ac70537ffd39/src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker#L170
-    for opensearch_dashboards_var in ${opensearch_dashboards_vars[*]}; do
-        env_var=$(echo ${opensearch_dashboards_var^^} | tr . _)
-        if [[ -v $env_var ]]; then
-            value=${!env_var}
-            set_yaml_prop "${OPENSEARCH_DASHBOARDS_CONF}" "${opensearch_dashboards_var}" "${value}"
-        fi
-    done
-}
-
 function start_opensearch_dashboards () {
     # start
     exec "${OPENSEARCH_DASHBOARDS_BIN}"/opensearch-dashboards \
@@ -50,6 +10,4 @@ function start_opensearch_dashboards () {
         -l "${OPENSEARCH_DASHBOARDS_VARLOG}"/opensearch_dashboards.log
 }
 
-set_base_config_props
-read_env_vars
 start_opensearch_dashboards


### PR DESCRIPTION
In the new K8s charm, we don't need to generate the default properties or the properties from the environment, because the charm will generate them. Currently, Rock overwrites the configurations after each restart. I have also added a run user to the services because otherwise dashboards will not run and will constantly display errors.

You can test this with k8s charm:
1. Build rock
```
rockcraft pack
```
2. Upload to microk8s locally
```
sudo microk8s enable registry
rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
  oci-archive:charmed-opensearch-dashboards_2.19.4_amd64.rock \
  docker://localhost:32000/osd-image:latest
```
3. Use this new image in [k8s charm](https://github.com/canonical/opensearch-dashboards-single-kernel-library/pull/6)
