### PR TITLE
Change exporter path

### DIFF
--- a/scripts/start-exporter.sh
+++ b/scripts/start-exporter.sh
@@ -9,6 +9,7 @@ function fetch_exporter_args () {
     DASHBOARDS_PORT=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.port" "5601" )
     DASHBOARDS_USER=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.username" "" )
     DASHBOARDS_PASSWORD=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "opensearch.password" "" )
+    DASHBOARDS_SERVER_PATH=$( get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.basePath" "" )
     ssl_enabled=$(get_yaml_prop "${OPENSEARCH_DASHBOARDS_PATH_CONF}/opensearch_dashboards.yml" "server.ssl.enabled" "false")
     if [[ "${ssl_enabled}" == "true" ]]; then
         SCHEME="https"
@@ -21,7 +22,7 @@ function start_exporter () {
     OPENSEARCH_DASHBOARDS_USER="${DASHBOARDS_USER}" \
     OPENSEARCH_DASHBOARDS_PASSWORD="${DASHBOARDS_PASSWORD}" \
     exec /usr/bin/prometheus-opensearch-dashboards-exporter \
-        --url ${SCHEME}://${DASHBOARDS_HOST}:${DASHBOARDS_PORT}
+        --url ${SCHEME}://${DASHBOARDS_HOST}:${DASHBOARDS_PORT}${DASHBOARDS_SERVER_PATH}
 }
 
 


### PR DESCRIPTION
If we add ingress to k8s charm it's base path changes to `/*model name*-opensearch-dashboards-k8s` so we need to update exporter path also